### PR TITLE
Remove contours when 'none' option is selected for wind arrows/barbs

### DIFF
--- a/TODO
+++ b/TODO
@@ -17,6 +17,7 @@ Check:
 Other bits
 - init transient can have boat id != null but no instruments (break at least predictor?)
 - non-existing chat channel in config (if made invisible) works?
+- Select/hover highlight for DCs
 - Reactivity fails for latLng (null -> non-null fails), at least delayLatLng
 - Miniscule wx cell TWS contours speed ups (draw only on edges)
 - Save leaderboard sort column
@@ -25,7 +26,6 @@ Other bits
 - POI notes field
 - Dual own trace removal when own boat is in fleettraces
 - Send steering button feedback improvement
-- Wind arrows/barbs none should remove also contours
 - Change tab while dc update in progress closes the editor?? Does it?
 - Steering retry & correct time offsets inside the post call's caller
 - Move wx cell size into frame to allow multi sized

--- a/TODO
+++ b/TODO
@@ -17,7 +17,6 @@ Check:
 Other bits
 - init transient can have boat id != null but no instruments (break at least predictor?)
 - non-existing chat channel in config (if made invisible) works?
-- Select/hover highlight for DCs
 - Reactivity fails for latLng (null -> non-null fails), at least delayLatLng
 - Miniscule wx cell TWS contours speed ups (draw only on edges)
 - Save leaderboard sort column


### PR DESCRIPTION
Contours should not be visible anymore when 'none' option is selected for wind arrows/barbs